### PR TITLE
Set cursor support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-input"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = "TUI input library supporting multiple backends"

--- a/examples/crossterm_input.rs
+++ b/examples/crossterm_input.rs
@@ -19,7 +19,7 @@ fn main() -> Result<()> {
     execute!(stdout, Hide, EnterAlternateScreen, EnableMouseCapture)?;
 
     let value = "Hello ".to_string();
-    let mut input = Input::default().with_cursor(value.len()).with_value(value);
+    let mut input = Input::default().with_value(value);
     backend::write(&mut stdout, input.value(), input.cursor(), (0, 0), 15)?;
     stdout.flush()?;
 

--- a/examples/termion_input.rs
+++ b/examples/termion_input.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
     let mut stdout = AlternateScreen::from(stdout);
 
     let value = "Hello ".to_string();
-    let mut input = Input::default().with_cursor(value.len()).with_value(value);
+    let mut input = Input::default().with_value(value);
     write!(&mut stdout, "{}", Hide)?;
     backend::write(&mut stdout, input.value(), input.cursor(), (0, 0), 15)?;
     stdout.flush()?;


### PR DESCRIPTION
- `with_value` auto sets the cursor.
- `with_cursor` auto adjusts based on the value.
- Use `InputRequest::SetCursor()` to set cursor to some specific value
  (auto adjusted).