### PR TITLE
Simplify API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-input"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = "TUI input library supporting multiple backends"

--- a/examples/termion_input.rs
+++ b/examples/termion_input.rs
@@ -1,5 +1,6 @@
 use std::io::{stdin, stdout, Result, Write};
 use termion::cursor::{Hide, Show};
+use termion::event::{Event, Key};
 use termion::input::TermRead;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
@@ -7,40 +8,47 @@ use tui_input::backend::termion as backend;
 use tui_input::{Input, InputResponse};
 
 fn main() -> Result<()> {
-    let stdin = stdin();
-    let stdout = stdout().into_raw_mode().unwrap();
-    let mut stdout = AlternateScreen::from(stdout);
+    let mut value = "Hello ".to_string();
+    {
+        let stdin = stdin();
+        let stdout = stdout().into_raw_mode().unwrap();
+        let mut stdout = AlternateScreen::from(stdout);
 
-    let value = "Hello ".to_string();
-    let mut input = Input::default().with_value(value);
-    write!(&mut stdout, "{}", Hide)?;
-    backend::write(&mut stdout, input.value(), input.cursor(), (0, 0), 15)?;
-    stdout.flush()?;
+        let mut input = Input::default().with_value(value);
+        write!(&mut stdout, "{}", Hide)?;
+        backend::write(&mut stdout, input.value(), input.cursor(), (0, 0), 15)?;
+        stdout.flush()?;
 
-    for evt in stdin.events() {
-        let evt = evt?;
-        if let Some(resp) =
-            backend::to_input_request(&evt).and_then(|req| input.handle(req))
-        {
-            match resp {
-                InputResponse::Escaped | InputResponse::Submitted => {
-                    break;
-                }
+        for evt in stdin.events() {
+            let evt = evt?;
+            if evt == Event::Key(Key::Esc) || evt == Event::Key(Key::Char('\n'))
+            {
+                break;
+            }
 
-                InputResponse::StateChanged(_) => {
-                    backend::write(
-                        &mut stdout,
-                        input.value(),
-                        input.cursor(),
-                        (0, 0),
-                        15,
-                    )?;
-                    stdout.flush()?;
+            if let Some(resp) =
+                backend::to_input_request(&evt).map(|req| input.handle(req))
+            {
+                match resp {
+                    InputResponse::StateChanged { .. } => {
+                        backend::write(
+                            &mut stdout,
+                            input.value(),
+                            input.cursor(),
+                            (0, 0),
+                            15,
+                        )?;
+                        stdout.flush()?;
+                    }
+                    _ => {}
                 }
             }
         }
+
+        value = input.value().to_string();
+        write!(stdout, "{}", Show)?;
     }
 
-    write!(stdout, "{}", Show)?;
+    println!("{}", value);
     Ok(())
 }

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -31,8 +31,6 @@ pub fn to_input_request(evt: CrosstermEvent) -> Option<InputRequest> {
                 (Delete, KeyModifiers::CONTROL) => Some(DeleteNextWord),
                 (Char('a'), KeyModifiers::CONTROL) => Some(GoToStart),
                 (Char('e'), KeyModifiers::CONTROL) => Some(GoToEnd),
-                (Enter, KeyModifiers::NONE) => Some(Submit),
-                (Esc, KeyModifiers::NONE) => Some(Escape),
                 (_, _) => None,
             }
         }

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -20,8 +20,6 @@ pub fn to_input_request(evt: &Event) -> Option<InputRequest> {
         // Event::Key(Key::Ctrl(Key::Delete)) => Some(DeleteNextWord),
         Event::Key(Key::Ctrl('a')) => Some(GoToStart),
         Event::Key(Key::Ctrl('e')) => Some(GoToEnd),
-        Event::Key(Key::Char('\n')) => Some(Submit),
-        Event::Key(Key::Esc) => Some(Escape),
         Event::Key(Key::Char(c)) => Some(InsertChar(c)),
         _ => None,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 //! TUI input library supporting multiple backends.
 //!
 //! # Example: Without any backend
-//!  
+//!
 //! ```
-//! use tui_input::{Input, InputRequest, InputResponse, StateChanged};
+//! use tui_input::{Input, InputRequest, InputResponse};
 //!
 //! let req = InputRequest::InsertChar('x');
 //! let mut input = Input::default();
-//! let resp = input.handle(req).unwrap();
+//! let resp = input.handle(req);
 //!
-//! assert_eq!(resp, InputResponse::StateChanged(StateChanged{ value: true, cursor: true }));
+//! assert_eq!(resp, InputResponse::StateChanged { value: true, cursor: true });
 //! assert_eq!(input.value(), "x");
 //! assert_eq!(input.cursor(), 1);
 //! ```
@@ -19,13 +19,4 @@
 mod input;
 
 pub mod backend;
-pub use input::{Input, InputRequest, InputResponse, StateChanged};
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}
+pub use input::{Input, InputRequest, InputResponse};


### PR DESCRIPTION
- `InputRequest::Submitted` and `InputRequest::Escapped` has been
  deprecated. Match against the keyboard event instead.
- `Input::handle` now returns `InputResponse` (not optional).
- The struct `StateChanged` has been deprecated. Use
  `InputResponse::StateChanged {..}`
- `InputResponse::Unchanged` is returned when neither the value, nor the
  cursor changes.