### PR TITLE
Make the API more convenient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-input"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = "TUI input library supporting multiple backends"
@@ -16,9 +16,9 @@ autoexamples = true
 default = ["crossterm"]
 
 [dependencies]
-crossterm = { version = "0.23", optional = true }
-serde = { version = "1.0", optional = true, features = ["derive"] }
-termion = { version = "1.5", optional = true }
+crossterm = { version = "0.23.2", optional = true }
+serde = { version = "1.0.137", optional = true, features = ["derive"] }
+termion = { version = "1.5.6", optional = true }
 
 [[example]]
 name = "crossterm_input"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 [![tui-input.gif](https://s10.gifyu.com/images/tui-input.gif)](https://github.com/sayanarijit/tui-input/blob/main/examples/tui-rs-input/src/main.rs)
 
-> **WARNING:** Most of the functionality is only human tested.
-
 A TUI input library supporting multiple backends.
 
 This crate can be used with [tui-rs](https://github.com/fdehau/tui-rs).
@@ -33,13 +31,17 @@ tui-input = { version = "*", features = ["termion"], default-features = false }
 
 See [examples](https://github.com/sayanarijit/tui-input/tree/main/examples).
 
+```bash
+# Run the example with crossterm as backend.
+cargo run --example crossterm_input
+
+# Run the example with termion as backend.
+cargo run --example termion_input --features termion
+
+# Run the tui-rs example
+(cd ./examples/tui-rs-input/ && cargo run)
+```
+
 ## Used in
 
 - [xplr](https://github.com/sayanarijit/xplr)
-
-## TODO
-
-- [x] [crossterm](https://github.com/crossterm-rs/crossterm) backend
-- [x] [termion](https://github.com/ticki/termion) backend
-- [ ] [rustbox](https://github.com/gchp/rustbox) backend
-- [ ] [pancurses](https://github.com/ihalila/pancurses) backend

--- a/examples/crossterm_input.rs
+++ b/examples/crossterm_input.rs
@@ -20,8 +20,7 @@ fn main() -> Result<()> {
     let mut stdout = stdout.lock();
     execute!(stdout, Hide, EnterAlternateScreen, EnableMouseCapture)?;
 
-    let value = "Hello ".to_string();
-    let mut input = Input::default().with_value(value);
+    let mut input: Input = "Hello ".into();
     backend::write(&mut stdout, input.value(), input.cursor(), (0, 0), 15)?;
     stdout.flush()?;
 
@@ -55,6 +54,6 @@ fn main() -> Result<()> {
 
     execute!(stdout, Show, LeaveAlternateScreen, DisableMouseCapture)?;
     disable_raw_mode()?;
-    println!("{}", input.value());
+    println!("{}", input);
     Ok(())
 }

--- a/examples/termion_input.rs
+++ b/examples/termion_input.rs
@@ -8,13 +8,12 @@ use tui_input::backend::termion as backend;
 use tui_input::Input;
 
 fn main() -> Result<()> {
-    let mut value = "Hello ".to_string();
+    let mut input: Input = "Hello ".into();
     {
         let stdin = stdin();
         let stdout = stdout().into_raw_mode().unwrap();
         let mut stdout = AlternateScreen::from(stdout);
 
-        let mut input = Input::default().with_value(value);
         write!(&mut stdout, "{}", Hide)?;
         backend::write(&mut stdout, input.value(), input.cursor(), (0, 0), 15)?;
         stdout.flush()?;
@@ -41,10 +40,9 @@ fn main() -> Result<()> {
             }
         }
 
-        value = input.value().to_string();
         write!(stdout, "{}", Show)?;
     }
 
-    println!("{}", value);
+    println!("{}", input);
     Ok(())
 }

--- a/examples/tui-rs-input/src/main.rs
+++ b/examples/tui-rs-input/src/main.rs
@@ -93,7 +93,7 @@ fn run_app<B: Backend>(
                 InputMode::Editing => match key.code {
                     KeyCode::Enter => {
                         app.messages.push(app.input.value().into());
-                        app.input = Input::default();
+                        app.input.reset();
                     }
                     KeyCode::Esc => {
                         app.input_mode = InputMode::Normal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,16 +5,17 @@
 //! ```
 //! use tui_input::{Input, InputRequest, StateChanged};
 //!
-//! let req = InputRequest::InsertChar('x');
-//! let mut input = Input::default();
+//! let mut input: Input = "Hello Worl".into();
+//!
+//! let req = InputRequest::InsertChar('d');
 //! let resp = input.handle(req);
 //!
 //! assert_eq!(resp, Some(StateChanged { value: true, cursor: true }));
-//! assert_eq!(input.value(), "x");
-//! assert_eq!(input.cursor(), 1);
+//! assert_eq!(input.cursor(), 11);
+//! assert_eq!(input.to_string(), "Hello World");
 //! ```
 //!
-//! See other examples on GitHub repository.
+//! See other examples in the [GitHub repo](https://github.com/sayanarijit/tui-input/tree/main/examples).
 
 mod input;
 


### PR DESCRIPTION
- Support `let input = Input::new("Hello");`
- Support `let input: Input = "Hello".into();`
- Support `let input: Input = String::new("Hello").into();`
- Support `let value: String = input.into();`
- Support `println!("{}", input);`
- Add method `input.reset();` to reset the values.
- Upgrade dependencies