### PR TITLE
Add support for more keys in crossterm.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-input"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = "TUI input library supporting multiple backends"
@@ -16,8 +16,8 @@ autoexamples = true
 default = ["crossterm"]
 
 [dependencies]
-crossterm = { version = "0.23.2", optional = true }
-serde = { version = "1.0.137", optional = true, features = ["derive"] }
+crossterm = { version = "0.25.0", optional = true }
+serde = { version = "1.0.144", optional = true, features = ["derive"] }
 termion = { version = "1.5.6", optional = true }
 
 [[example]]

--- a/src/input.rs
+++ b/src/input.rs
@@ -17,6 +17,7 @@ pub enum InputRequest {
     DeletePrevWord,
     DeleteNextWord,
     DeleteLine,
+    DeleteTillEnd,
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
@@ -299,6 +300,14 @@ impl Input {
                         cursor: true,
                     })
                 }
+            }
+
+            DeleteTillEnd => {
+                self.value = self.value.chars().take(self.cursor).collect();
+                Some(StateChanged {
+                    value: true,
+                    cursor: false,
+                })
             }
         }
     }


### PR DESCRIPTION
Following keys are now supported in crossterm

- ctrl-h
- ctrl-b
- ctrl-f
- meta-b
- meta-f
- home
- end
- ctrl-k

Added a kew input request

- DeleteTillEnd