### PR TITLE
Simplify API further using trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-input"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = "TUI input library supporting multiple backends"
@@ -17,7 +17,7 @@ default = ["crossterm"]
 
 [dependencies]
 crossterm = { version = "0.25.0", optional = true }
-serde = { version = "1.0.144", optional = true, features = ["derive"] }
+serde = { version = "1.0.145", optional = true, features = ["derive"] }
 termion = { version = "1.5.6", optional = true }
 
 [[example]]

--- a/examples/crossterm_input.rs
+++ b/examples/crossterm_input.rs
@@ -9,6 +9,7 @@ use crossterm::{
 };
 use std::io::{stdout, Write};
 use tui_input::backend::crossterm as backend;
+use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
 fn main() -> Result<()> {
@@ -30,10 +31,7 @@ fn main() -> Result<()> {
                     break;
                 }
                 _ => {
-                    if backend::to_input_request(event)
-                        .and_then(|r| input.handle(r))
-                        .is_some()
-                    {
+                    if input.handle_event(&event).is_some() {
                         backend::write(
                             &mut stdout,
                             input.value(),

--- a/examples/termion_input.rs
+++ b/examples/termion_input.rs
@@ -5,6 +5,7 @@ use termion::input::TermRead;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui_input::backend::termion as backend;
+use tui_input::backend::termion::EventHandler;
 use tui_input::Input;
 
 fn main() -> Result<()> {
@@ -24,10 +25,7 @@ fn main() -> Result<()> {
                 break;
             }
 
-            if backend::to_input_request(&evt)
-                .and_then(|req| input.handle(req))
-                .is_some()
-            {
+            if input.handle_event(&evt).is_some() {
                 backend::write(&mut stdout, input.value(), input.cursor(), (0, 0), 15)?;
                 stdout.flush()?;
             }

--- a/examples/tui-rs-input/Cargo.toml
+++ b/examples/tui-rs-input/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossterm = "0.23.2"
-tui = { version = "0.18.0", features = ["crossterm"] }
+crossterm = "0.25.0"
+tui = { version = "0.19.0", features = ["crossterm"] }
 tui-input = { path = "../../" }
-unicode-width = "0.1.9"
+unicode-width = "0.1.10"

--- a/examples/tui-rs-input/src/main.rs
+++ b/examples/tui-rs-input/src/main.rs
@@ -16,6 +16,7 @@ use tui::{
     Frame, Terminal,
 };
 use tui_input::backend::crossterm as input_backend;
+use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
 enum InputMode {
@@ -95,8 +96,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                         app.input_mode = InputMode::Normal;
                     }
                     _ => {
-                        input_backend::to_input_request(Event::Key(key))
-                            .and_then(|req| app.input.handle(req));
+                        app.input.handle_event(&Event::Key(key));
                     }
                 },
             }

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -1,4 +1,6 @@
 use crate::input::InputRequest;
+use crate::Input;
+use crate::StateChanged;
 use std::io::{Result, Write};
 use termion::cursor::Goto;
 use termion::event::{Event, Key};
@@ -62,6 +64,16 @@ pub fn write<W: Write>(
     }
 
     Ok(())
+}
+
+pub trait EventHandler {
+    fn handle_event(&mut self, evt: &Event) -> Option<StateChanged>;
+}
+
+impl EventHandler for Input {
+    fn handle_event(&mut self, evt: &Event) -> Option<StateChanged> {
+        to_input_request(evt).and_then(|req| self.handle(req))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
BREAKING: crossterm's to_input_request now takes a reference to the event.