### PR TITLE
Handling multi-space characters (Japanese, Chinese...) width better

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = ["crossterm"]
 crossterm = { version = "0.25.0", optional = true }
 serde = { version = "1.0.145", optional = true, features = ["derive"] }
 termion = { version = "1.5.6", optional = true }
+unicode-width = "0.1.4"
 
 [[example]]
 name = "crossterm_input"

--- a/src/input.rs
+++ b/src/input.rs
@@ -321,6 +321,22 @@ impl Input {
     pub fn cursor(&self) -> usize {
         self.cursor
     }
+
+    /// Get the current cursor position with account for multispace characters.
+    pub fn visual_cursor(&self) -> usize {
+        if self.cursor == 0 {
+            return 0
+        }
+
+        // Safe, because the end index will always be within bounds
+        unicode_width::UnicodeWidthStr::width(unsafe {
+                self.value.get_unchecked(
+                    0..
+                    self.value.char_indices()
+                    .nth(self.cursor)
+                    .map_or_else(|| self.value.len(), |(index, _)| index))
+        })
+    }
 }
 
 impl From<Input> for String {


### PR DESCRIPTION
Continuing [#530](https://github.com/sayanarijit/xplr/pull/530), i added `visual_cursor` method as discussed, but currently fighting incorrect display at scroll position.

Currently I'm not sure if code in example is to blame or [tui-rs](https://github.com/fdehau/tui-rs). Investigating.