### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-input"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 authors = ["Arijit Basu <hi@arijitbasu.in>"]
 description = "TUI input library supporting multiple backends"
@@ -16,8 +16,8 @@ autoexamples = true
 default = ["crossterm"]
 
 [dependencies]
-crossterm = { version = "0.26.1", optional = true }
-serde = { version = "1.0.163", optional = true, features = ["derive"] }
+crossterm = { version = "0.27.0", optional = true }
+serde = { version = "1.0.183", optional = true, features = ["derive"] }
 termion = { version = "2.0.1", optional = true }
 unicode-width = "0.1.10"
 

--- a/examples/crossterm_input.rs
+++ b/examples/crossterm_input.rs
@@ -5,9 +5,8 @@ use crossterm::{
     terminal::{
         disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
     },
-    Result,
 };
-use std::io::{stdout, Write};
+use std::io::{stdout, Result, Write};
 use tui_input::backend::crossterm as backend;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;

--- a/examples/ratatui-input/Cargo.toml
+++ b/examples/ratatui-input/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossterm = "0.26.1"
-tui = { package = "ratatui", version = "0.21.0", features = ["crossterm"] }
+crossterm = "0.27.0"
+tui = { package = "ratatui", git = "https://github.com/a-kenji/ratatui", branch = "update/crossterm", features = ["crossterm"] }
 tui-input = { path = "../../" }
 unicode-width = "0.1.10"

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -6,9 +6,8 @@ use crossterm::{
     cursor::MoveTo,
     queue,
     style::{Attribute as CAttribute, Print, SetAttribute},
-    Result,
 };
-use std::io::Write;
+use std::io::{Result, Write};
 
 /// Converts crossterm event into input requests.
 pub fn to_input_request(evt: &CrosstermEvent) -> Option<InputRequest> {


### PR DESCRIPTION
Breaking change:

Crossterm major update, specifically tui_input::backend::crossterm::write  will return std::io::Result instead of crossterm::Result.