### PR TITLE
feat: migrate from crossterm to ratatui::crossterm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ autoexamples = true
 
 [features]
 default = ["crossterm"]
+crossterm = ["dep:ratatui"]
 
 [dependencies]
-crossterm = { version = "0.27.0", optional = true }
+ratatui = { version = "0.28", optional = true }
 serde = { version = "1.0.203", optional = true, features = ["derive"] }
 termion = { version = "4.0.2", optional = true }
 unicode-width = "0.1.13"

--- a/examples/crossterm_input.rs
+++ b/examples/crossterm_input.rs
@@ -1,4 +1,4 @@
-use crossterm::{
+use ratatui::crossterm::{
     cursor::{Hide, Show},
     event::{read, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent},
     execute,

--- a/examples/ratatui-input/Cargo.toml
+++ b/examples/ratatui-input/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossterm = "0.27"
-ratatui = "0.27"
+ratatui = "0.28"
 tui-input = { path = "../../" }
 unicode-width = "0.1.13"

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -1,8 +1,8 @@
 use crate::{Input, InputRequest, StateChanged};
-use crossterm::event::{
+use ratatui::crossterm::event::{
     Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
 };
-use crossterm::{
+use ratatui::crossterm::{
     cursor::MoveTo,
     queue,
     style::{Attribute as CAttribute, Print, SetAttribute},
@@ -117,7 +117,7 @@ impl EventHandler for Input {
 
 #[cfg(test)]
 mod tests {
-    use crossterm::event::{KeyEventKind, KeyEventState};
+    use ratatui::crossterm::event::{KeyEventKind, KeyEventState};
 
     use super::*;
 


### PR DESCRIPTION
With the new release 0.28 of ratatui, crossterm is re-exported by ratatui.

As tui-input is intended to be used with ratatui, it would be best, to use ratatui's re-export of crossterm. This way, there is no need to manually find a version of tui-input that matches crossterm AND ratatui, but only tui-input and ratattui would be needed to find matching versions.