### PR TITLE
add ALT-BACKSPACE to crossterm's to_input_request

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -41,7 +41,8 @@ pub fn to_input_request(evt: &CrosstermEvent) -> Option<InputRequest> {
 
             (Char('w'), KeyModifiers::CONTROL)
             | (Char('d'), KeyModifiers::META)
-            | (Backspace, KeyModifiers::META) => Some(DeletePrevWord),
+            | (Backspace, KeyModifiers::META)
+            | (Backspace, KeyModifiers::ALT) => Some(DeletePrevWord),
 
             (Delete, KeyModifiers::CONTROL) => Some(DeleteNextWord),
             (Char('k'), KeyModifiers::CONTROL) => Some(DeleteTillEnd),


### PR DESCRIPTION
ALT-BACKSPACE deletes previous word for various terminal apps like fish or helix editor (I think this keybinding comes from emacs so bash probably respects this keybinding by default too).

I see that there's also a corresponding function for termion, but it doesn't functionally correspond to crossterm's implementation nor isn't documented on docs.rs (both of which issues I could try to tackle in a new PR)