### PR TITLE
Do not depend on alpha versions of ratatui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ unicode-width = "0.2.0"
 serde = { version = "1.0.218", optional = true, features = ["derive"] }
 crossterm = { version = "0.29.0", optional = true }
 termion = { version = "4.0.4", optional = true }
-ratatui = { version = "0.30.0-alpha.2", optional = true, features = [
+ratatui = { version = "0.29.0", optional = true, features = [
   "crossterm",
 ] }
 


### PR DESCRIPTION
Please don't depend on alpha versions of ratatui, your users don't want to update their stuff to unstable versions!
