### PR TITLE
Pull input text into a separate type with cached codepoint count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build
         run: cargo build
       - name: Run tests
-        run: cargo test
+        run: cargo test --all-features
       - name: Run lint
         run: cargo clippy -- -D warnings
       - name: Run fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ termion = { version = "4.0.6", optional = true }
 ratatui = { version = "0.30.0", optional = true, features = ["crossterm"] }
 
 [dev-dependencies]
+serde_json = "1.0"
 
 [[example]]
 name = "crossterm_input"

--- a/src/input.rs
+++ b/src/input.rs
@@ -37,7 +37,11 @@
 //! assert_eq!(input.to_string(), "Hello World");
 //! ```
 
+mod value;
+
 use unicode_segmentation::{GraphemeCursor, UnicodeSegmentation};
+
+use self::value::Value;
 
 fn prev_grapheme(s: &str, byte: usize) -> Option<usize> {
     GraphemeCursor::new(byte, s.len(), true)
@@ -141,7 +145,7 @@ pub type InputResponse = Option<StateChanged>;
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Input {
-    value: String,
+    value: Value,
     /// Codepoints preceding the cursor.  See the module-level `Units` section.
     cursor: usize,
     yank: String,
@@ -152,10 +156,11 @@ impl Input {
     /// Initialize a new instance with a given value
     /// Cursor will be set to the given value's length.
     pub fn new(value: String) -> Self {
-        let len = value.chars().count();
+        let value = Value::new(value);
+        let cursor = value.chars();
         Self {
             value,
-            cursor: len,
+            cursor,
             yank: String::new(),
             last_was_cut: false,
         }
@@ -164,15 +169,15 @@ impl Input {
     /// Set the value manually.
     /// Cursor will be set to the given value's length.
     pub fn with_value(mut self, value: String) -> Self {
-        self.cursor = value.chars().count();
-        self.value = value;
+        self.value = Value::new(value);
+        self.cursor = self.value.chars();
         self
     }
 
     /// Set the cursor manually.
     /// If the input is larger than the value length, it'll be auto adjusted.
     pub fn with_cursor(mut self, cursor: usize) -> Self {
-        self.cursor = cursor.min(self.value.chars().count());
+        self.cursor = cursor.min(self.value.chars());
         self
     }
 
@@ -184,7 +189,7 @@ impl Input {
 
     // Reset the cursor and value to default, returning the previous value
     pub fn value_and_reset(&mut self) -> String {
-        let val = self.value.clone();
+        let val = self.value.as_str().to_owned();
         self.reset();
         val
     }
@@ -213,7 +218,7 @@ impl Input {
         use InputRequest::*;
         let result = match req {
             SetCursor(pos) => {
-                let pos = pos.min(self.value.chars().count());
+                let pos = pos.min(self.value.chars());
                 if self.cursor == pos {
                     None
                 } else {
@@ -225,19 +230,8 @@ impl Input {
                 }
             }
             InsertChar(c) => {
-                if self.cursor == self.value.chars().count() {
-                    self.value.push(c);
-                } else {
-                    self.value = self
-                        .value
-                        .chars()
-                        .take(self.cursor)
-                        .chain(
-                            std::iter::once(c)
-                                .chain(self.value.chars().skip(self.cursor)),
-                        )
-                        .collect();
-                }
+                let byte = codepoint_to_byte(self.value.as_str(), self.cursor);
+                self.value.edit().insert(byte, c);
                 self.cursor += 1;
                 Some(StateChanged {
                     value: true,
@@ -246,10 +240,11 @@ impl Input {
             }
 
             DeletePrevChar => {
-                let byte = codepoint_to_byte(&self.value, self.cursor);
-                let prev = prev_grapheme(&self.value, byte)?;
-                let removed = self.value[prev..byte].chars().count();
-                self.value.replace_range(prev..byte, "");
+                let s = self.value.as_str();
+                let byte = codepoint_to_byte(s, self.cursor);
+                let prev = prev_grapheme(s, byte)?;
+                let removed = s[prev..byte].chars().count();
+                self.value.edit().replace_range(prev..byte, "");
                 self.cursor -= removed;
                 Some(StateChanged {
                     value: true,
@@ -258,9 +253,10 @@ impl Input {
             }
 
             DeleteNextChar => {
-                let byte = codepoint_to_byte(&self.value, self.cursor);
-                let next = next_grapheme(&self.value, byte)?;
-                self.value.replace_range(byte..next, "");
+                let s = self.value.as_str();
+                let byte = codepoint_to_byte(s, self.cursor);
+                let next = next_grapheme(s, byte)?;
+                self.value.edit().replace_range(byte..next, "");
                 Some(StateChanged {
                     value: true,
                     cursor: false,
@@ -268,9 +264,10 @@ impl Input {
             }
 
             GoToPrevChar => {
-                let byte = codepoint_to_byte(&self.value, self.cursor);
-                let prev = prev_grapheme(&self.value, byte)?;
-                self.cursor -= self.value[prev..byte].chars().count();
+                let s = self.value.as_str();
+                let byte = codepoint_to_byte(s, self.cursor);
+                let prev = prev_grapheme(s, byte)?;
+                self.cursor -= s[prev..byte].chars().count();
                 Some(StateChanged {
                     value: false,
                     cursor: true,
@@ -278,12 +275,13 @@ impl Input {
             }
 
             GoToPrevWord => {
-                let byte = codepoint_to_byte(&self.value, self.cursor);
-                let prev = prev_word_byte(&self.value, byte);
+                let s = self.value.as_str();
+                let byte = codepoint_to_byte(s, self.cursor);
+                let prev = prev_word_byte(s, byte);
                 if self.cursor == 0 {
                     None
                 } else {
-                    self.cursor = byte_to_codepoint(&self.value, prev);
+                    self.cursor = byte_to_codepoint(s, prev);
                     Some(StateChanged {
                         value: false,
                         cursor: true,
@@ -292,9 +290,10 @@ impl Input {
             }
 
             GoToNextChar => {
-                let byte = codepoint_to_byte(&self.value, self.cursor);
-                let next = next_grapheme(&self.value, byte)?;
-                self.cursor += self.value[byte..next].chars().count();
+                let s = self.value.as_str();
+                let byte = codepoint_to_byte(s, self.cursor);
+                let next = next_grapheme(s, byte)?;
+                self.cursor += s[byte..next].chars().count();
                 Some(StateChanged {
                     value: false,
                     cursor: true,
@@ -302,12 +301,13 @@ impl Input {
             }
 
             GoToNextWord => {
-                let byte = codepoint_to_byte(&self.value, self.cursor);
-                let next = next_word_byte(&self.value, byte);
-                if self.cursor == self.value.chars().count() {
+                let s = self.value.as_str();
+                let byte = codepoint_to_byte(s, self.cursor);
+                let next = next_word_byte(s, byte);
+                if self.cursor == self.value.chars() {
                     None
                 } else {
-                    self.cursor = byte_to_codepoint(&self.value, next);
+                    self.cursor = byte_to_codepoint(s, next);
                     Some(StateChanged {
                         value: false,
                         cursor: true,
@@ -316,16 +316,16 @@ impl Input {
             }
 
             DeleteLine => {
-                if self.value.is_empty() {
+                if self.value.as_str().is_empty() {
                     None
                 } else {
-                    let side = if self.cursor == self.value.chars().count() {
+                    let side = if self.cursor == self.value.chars() {
                         Side::Left
                     } else {
                         Side::Right
                     };
-                    self.add_to_yank(self.value.clone(), side);
-                    self.value = "".into();
+                    self.add_to_yank(self.value.as_str().to_owned(), side);
+                    self.value.edit().clear();
                     self.cursor = 0;
                     Some(StateChanged {
                         value: true,
@@ -338,12 +338,13 @@ impl Input {
                 if self.cursor == 0 {
                     None
                 } else {
-                    let byte = codepoint_to_byte(&self.value, self.cursor);
-                    let prev = prev_word_byte(&self.value, byte);
-                    let deleted = self.value[prev..byte].to_string();
+                    let s = self.value.as_str();
+                    let byte = codepoint_to_byte(s, self.cursor);
+                    let prev = prev_word_byte(s, byte);
+                    let deleted = s[prev..byte].to_string();
                     self.add_to_yank(deleted, Side::Left);
-                    self.value.replace_range(prev..byte, "");
-                    self.cursor = byte_to_codepoint(&self.value, prev);
+                    self.value.edit().replace_range(prev..byte, "");
+                    self.cursor = byte_to_codepoint(self.value.as_str(), prev);
                     Some(StateChanged {
                         value: true,
                         cursor: true,
@@ -352,14 +353,15 @@ impl Input {
             }
 
             DeleteNextWord => {
-                let byte = codepoint_to_byte(&self.value, self.cursor);
-                let next = next_word_byte(&self.value, byte);
-                if self.cursor == self.value.chars().count() {
+                let s = self.value.as_str();
+                let byte = codepoint_to_byte(s, self.cursor);
+                let next = next_word_byte(s, byte);
+                if self.cursor == self.value.chars() {
                     None
                 } else {
-                    let deleted = self.value[byte..next].to_string();
+                    let deleted = s[byte..next].to_string();
                     self.add_to_yank(deleted, Side::Right);
-                    self.value.replace_range(byte..next, "");
+                    self.value.edit().replace_range(byte..next, "");
                     Some(StateChanged {
                         value: true,
                         cursor: false,
@@ -380,7 +382,7 @@ impl Input {
             }
 
             GoToEnd => {
-                let count = self.value.chars().count();
+                let count = self.value.chars();
                 if self.cursor == count {
                     None
                 } else {
@@ -393,9 +395,10 @@ impl Input {
             }
 
             DeleteTillEnd => {
-                let deleted: String = self.value.chars().skip(self.cursor).collect();
+                let byte = codepoint_to_byte(self.value.as_str(), self.cursor);
+                let deleted = self.value.as_str()[byte..].to_string();
                 self.add_to_yank(deleted, Side::Right);
-                self.value = self.value.chars().take(self.cursor).collect();
+                self.value.edit().truncate(byte);
                 Some(StateChanged {
                     value: true,
                     cursor: false,
@@ -405,21 +408,9 @@ impl Input {
             Yank => {
                 if self.yank.is_empty() {
                     None
-                } else if self.cursor == self.value.chars().count() {
-                    self.value.push_str(&self.yank);
-                    self.cursor += self.yank.chars().count();
-                    Some(StateChanged {
-                        value: true,
-                        cursor: true,
-                    })
                 } else {
-                    self.value = self
-                        .value
-                        .chars()
-                        .take(self.cursor)
-                        .chain(self.yank.chars())
-                        .chain(self.value.chars().skip(self.cursor))
-                        .collect();
+                    let byte = codepoint_to_byte(self.value.as_str(), self.cursor);
+                    self.value.edit().insert_str(byte, &self.yank);
                     self.cursor += self.yank.chars().count();
                     Some(StateChanged {
                         value: true,
@@ -452,14 +443,13 @@ impl Input {
             return 0;
         }
 
+        let s = self.value.as_str();
         // Safe, because the end index will always be within bounds
         unicode_width::UnicodeWidthStr::width(unsafe {
-            self.value.get_unchecked(
-                0..self
-                    .value
-                    .char_indices()
+            s.get_unchecked(
+                0..s.char_indices()
                     .nth(self.cursor)
-                    .map_or_else(|| self.value.len(), |(index, _)| index),
+                    .map_or_else(|| s.len(), |(index, _)| index),
             )
         })
     }
@@ -484,7 +474,7 @@ impl Input {
 
 impl From<Input> for String {
     fn from(input: Input) -> Self {
-        input.value
+        input.value.into()
     }
 }
 
@@ -502,7 +492,7 @@ impl From<&str> for Input {
 
 impl std::fmt::Display for Input {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.value.fmt(f)
+        self.value.as_str().fmt(f)
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -148,7 +148,7 @@ pub struct Input {
     value: Value,
     /// Codepoints preceding the cursor.  See the module-level `Units` section.
     cursor: usize,
-    yank: String,
+    yank: Value,
     last_was_cut: bool,
 }
 
@@ -161,7 +161,7 @@ impl Input {
         Self {
             value,
             cursor,
-            yank: String::new(),
+            yank: Value::default(),
             last_was_cut: false,
         }
     }
@@ -197,11 +197,11 @@ impl Input {
     fn add_to_yank(&mut self, deleted: String, side: Side) {
         if self.last_was_cut {
             match side {
-                Side::Left => self.yank.insert_str(0, &deleted),
-                Side::Right => self.yank.push_str(&deleted),
+                Side::Left => self.yank.edit().insert_str(0, &deleted),
+                Side::Right => self.yank.edit().push_str(&deleted),
             }
         } else {
-            self.yank = deleted;
+            self.yank = Value::new(deleted);
         }
     }
 
@@ -406,12 +406,12 @@ impl Input {
             }
 
             Yank => {
-                if self.yank.is_empty() {
+                if self.yank.as_str().is_empty() {
                     None
                 } else {
                     let byte = codepoint_to_byte(self.value.as_str(), self.cursor);
-                    self.value.edit().insert_str(byte, &self.yank);
-                    self.cursor += self.yank.chars().count();
+                    self.value.edit().insert_str(byte, self.yank.as_str());
+                    self.cursor += self.yank.chars();
                     Some(StateChanged {
                         value: true,
                         cursor: true,

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -190,12 +190,12 @@ fn yank_delete_line() {
     input.handle(InputRequest::DeleteLine);
     assert_eq!(input.value(), "");
     assert_eq!(input.cursor(), 0);
-    assert_eq!(input.yank, TEXT);
+    assert_eq!(input.yank.as_str(), TEXT);
 
     input.handle(InputRequest::Yank);
     assert_eq!(input.value(), TEXT);
     assert_eq!(input.cursor(), TEXT.chars().count());
-    assert_eq!(input.yank, TEXT);
+    assert_eq!(input.yank.as_str(), TEXT);
 }
 
 #[test]
@@ -204,12 +204,12 @@ fn yank_delete_till_end() {
     input.handle(InputRequest::DeleteTillEnd);
     assert_eq!(input.value(), "first ");
     assert_eq!(input.cursor(), 6);
-    assert_eq!(input.yank, "second, third.");
+    assert_eq!(input.yank.as_str(), "second, third.");
 
     input.handle(InputRequest::Yank);
     assert_eq!(input.value(), "first second, third.");
     assert_eq!(input.cursor(), TEXT.chars().count());
-    assert_eq!(input.yank, "second, third.");
+    assert_eq!(input.yank.as_str(), "second, third.");
 }
 
 #[test]
@@ -217,11 +217,11 @@ fn yank_delete_prev_word() {
     let mut input = Input::from(TEXT).with_cursor(12);
     input.handle(InputRequest::DeletePrevWord);
     assert_eq!(input.value(), "first , third.");
-    assert_eq!(input.yank, "second");
+    assert_eq!(input.yank.as_str(), "second");
 
     input.handle(InputRequest::Yank);
     assert_eq!(input.value(), "first second, third.");
-    assert_eq!(input.yank, "second");
+    assert_eq!(input.yank.as_str(), "second");
 }
 
 #[test]
@@ -229,11 +229,11 @@ fn yank_delete_next_word() {
     let mut input = Input::from(TEXT).with_cursor(6);
     input.handle(InputRequest::DeleteNextWord);
     assert_eq!(input.value(), "first third.");
-    assert_eq!(input.yank, "second, ");
+    assert_eq!(input.yank.as_str(), "second, ");
 
     input.handle(InputRequest::Yank);
     assert_eq!(input.value(), "first second, third.");
-    assert_eq!(input.yank, "second, ");
+    assert_eq!(input.yank.as_str(), "second, ");
 }
 
 #[test]
@@ -242,7 +242,7 @@ fn yank_empty() {
     let result = input.handle(InputRequest::Yank);
     assert_eq!(result, None);
     assert_eq!(input.value(), TEXT);
-    assert_eq!(input.yank, "");
+    assert_eq!(input.yank.as_str(), "");
 }
 
 #[test]
@@ -250,12 +250,12 @@ fn yank_at_middle() {
     let mut input = Input::from(TEXT).with_cursor(6);
     input.handle(InputRequest::DeleteTillEnd);
     assert_eq!(input.value(), "first ");
-    assert_eq!(input.yank, "second, third.");
+    assert_eq!(input.yank.as_str(), "second, third.");
     input.handle(InputRequest::GoToStart);
     input.handle(InputRequest::Yank);
     assert_eq!(input.value(), "second, third.first ");
     assert_eq!(input.cursor(), 14);
-    assert_eq!(input.yank, "second, third.");
+    assert_eq!(input.yank.as_str(), "second, third.");
 }
 
 #[test]
@@ -263,10 +263,10 @@ fn yank_consecutive_delete_prev_word() {
     let mut input = Input::from(TEXT).with_cursor(TEXT.chars().count());
     input.handle(InputRequest::DeletePrevWord);
     assert_eq!(input.value(), "first second, ");
-    assert_eq!(input.yank, "third.");
+    assert_eq!(input.yank.as_str(), "third.");
     input.handle(InputRequest::DeletePrevWord);
     assert_eq!(input.value(), "first ");
-    assert_eq!(input.yank, "second, third.");
+    assert_eq!(input.yank.as_str(), "second, third.");
     input.handle(InputRequest::Yank);
     assert_eq!(input.value(), "first second, third.");
 }
@@ -276,10 +276,10 @@ fn yank_consecutive_delete_next_word() {
     let mut input = Input::from(TEXT).with_cursor(0);
     input.handle(InputRequest::DeleteNextWord);
     assert_eq!(input.value(), "second, third.");
-    assert_eq!(input.yank, "first ");
+    assert_eq!(input.yank.as_str(), "first ");
     input.handle(InputRequest::DeleteNextWord);
     assert_eq!(input.value(), "third.");
-    assert_eq!(input.yank, "first second, ");
+    assert_eq!(input.yank.as_str(), "first second, ");
     input.handle(InputRequest::Yank);
     assert_eq!(input.value(), "first second, third.");
 }
@@ -288,11 +288,11 @@ fn yank_consecutive_delete_next_word() {
 fn yank_insert_breaks_cut_sequence() {
     let mut input = Input::from(TEXT).with_cursor(TEXT.chars().count());
     input.handle(InputRequest::DeletePrevWord);
-    assert_eq!(input.yank, "third.");
+    assert_eq!(input.yank.as_str(), "third.");
     input.handle(InputRequest::InsertChar('x'));
     input.handle(InputRequest::DeletePrevChar);
     input.handle(InputRequest::DeletePrevWord);
-    assert_eq!(input.yank, "second, ");
+    assert_eq!(input.yank.as_str(), "second, ");
 }
 
 #[test]
@@ -300,10 +300,10 @@ fn yank_mixed_delete_word_and_line() {
     let mut input = Input::from(TEXT).with_cursor(6);
     input.handle(InputRequest::DeletePrevWord);
     assert_eq!(input.value(), "second, third.");
-    assert_eq!(input.yank, "first ");
+    assert_eq!(input.yank.as_str(), "first ");
     input.handle(InputRequest::DeleteLine);
     assert_eq!(input.value(), "");
-    assert_eq!(input.yank, "first second, third.");
+    assert_eq!(input.yank.as_str(), "first second, third.");
     input.handle(InputRequest::Yank);
     assert_eq!(input.value(), "first second, third.");
 }
@@ -313,10 +313,10 @@ fn yank_mixed_delete_word_and_line_from_end() {
     let mut input = Input::from(TEXT).with_cursor(TEXT.chars().count());
     input.handle(InputRequest::DeletePrevWord);
     assert_eq!(input.value(), "first second, ");
-    assert_eq!(input.yank, "third.");
+    assert_eq!(input.yank.as_str(), "third.");
     input.handle(InputRequest::DeleteLine);
     assert_eq!(input.value(), "");
-    assert_eq!(input.yank, "first second, third.");
+    assert_eq!(input.yank.as_str(), "first second, third.");
     input.handle(InputRequest::Yank);
     assert_eq!(input.value(), "first second, third.");
 }

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -391,7 +391,7 @@ fn word_movement_comprehensive() {
     // Next word
     input.handle(InputRequest::GoToNextWord);
     assert_eq!(
-        input.value()[codepoint_to_byte(&input.value, input.cursor())..]
+        input.value()[codepoint_to_byte(input.value(), input.cursor())..]
             .chars()
             .next(),
         Some('w')
@@ -400,7 +400,7 @@ fn word_movement_comprehensive() {
     input.handle(InputRequest::GoToNextWord);
     // "🤦🏼‍♂️" is now considered a word.
     assert_eq!(
-        input.value()[codepoint_to_byte(&input.value, input.cursor())..]
+        input.value()[codepoint_to_byte(input.value(), input.cursor())..]
             .chars()
             .next(),
         Some('🤦')
@@ -408,7 +408,7 @@ fn word_movement_comprehensive() {
 
     input.handle(InputRequest::GoToNextWord);
     assert_eq!(
-        input.value()[codepoint_to_byte(&input.value, input.cursor())..]
+        input.value()[codepoint_to_byte(input.value(), input.cursor())..]
             .chars()
             .next(),
         Some('o')
@@ -417,7 +417,7 @@ fn word_movement_comprehensive() {
     // Prev word
     input.handle(InputRequest::GoToPrevWord);
     assert_eq!(
-        input.value()[codepoint_to_byte(&input.value, input.cursor())..]
+        input.value()[codepoint_to_byte(input.value(), input.cursor())..]
             .chars()
             .next(),
         Some('🤦')
@@ -425,7 +425,7 @@ fn word_movement_comprehensive() {
 
     input.handle(InputRequest::GoToPrevWord);
     assert_eq!(
-        input.value()[codepoint_to_byte(&input.value, input.cursor())..]
+        input.value()[codepoint_to_byte(input.value(), input.cursor())..]
             .chars()
             .next(),
         Some('w')
@@ -433,7 +433,7 @@ fn word_movement_comprehensive() {
 
     input.handle(InputRequest::GoToPrevWord);
     assert_eq!(
-        input.value()[codepoint_to_byte(&input.value, input.cursor())..]
+        input.value()[codepoint_to_byte(input.value(), input.cursor())..]
             .chars()
             .next(),
         Some('H')

--- a/src/input/value.rs
+++ b/src/input/value.rs
@@ -1,0 +1,78 @@
+use std::ops::{Deref, DerefMut};
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(from = "String", into = "String"))]
+pub(super) struct Value {
+    s: String,
+    chars: usize,
+}
+
+impl Value {
+    pub(super) fn new<T>(s: T) -> Self
+    where
+        T: Into<String>,
+    {
+        let s = s.into();
+        let chars = s.chars().count();
+        Self { s, chars }
+    }
+
+    pub(super) fn as_str(&self) -> &str {
+        &self.s
+    }
+
+    pub(super) fn chars(&self) -> usize {
+        self.chars
+    }
+
+    pub(super) fn edit(&mut self) -> ValueMut<'_> {
+        ValueMut {
+            v: self,
+            dirty: false,
+        }
+    }
+}
+
+impl From<String> for Value {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<Value> for String {
+    fn from(v: Value) -> Self {
+        v.s
+    }
+}
+
+pub(super) struct ValueMut<'a> {
+    v: &'a mut Value,
+    dirty: bool,
+}
+
+impl Deref for ValueMut<'_> {
+    type Target = String;
+
+    fn deref(&self) -> &String {
+        &self.v.s
+    }
+}
+
+impl DerefMut for ValueMut<'_> {
+    fn deref_mut(&mut self) -> &mut String {
+        self.dirty = true;
+        &mut self.v.s
+    }
+}
+
+impl Drop for ValueMut<'_> {
+    fn drop(&mut self) {
+        if self.dirty {
+            self.v.chars = self.v.s.chars().count();
+        }
+    }
+}

--- a/src/input/value/tests.rs
+++ b/src/input/value/tests.rs
@@ -1,0 +1,13 @@
+#[cfg(feature = "serde")]
+mod serde {
+    use crate::input::Value;
+
+    #[test]
+    fn serde_roundtrip() {
+        const STR: &str = "hello äëïöü 한국 🤦";
+        let a = Value::new(STR);
+        let json = serde_json::to_string(&a).unwrap();
+        let b: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, b);
+    }
+}


### PR DESCRIPTION
Several editing or movement operations iterated the entire input string in order to count characters.  It would be better to cache the count but in a way that is automatic and not subject to careful maintenance.

We pull the text into a `Value` type, which only allows modifying the contained string via a guard object (`ValueMut`), which in turn derefs into the contained string.  When the guard is dropped after a mutable deref, the cached character count is updated.  Several operations are then optimized.